### PR TITLE
Add "raw=" arg to all domain/email calls; Add "company=" to email_verifier().

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,20 @@ You can check the deliverability of a given email adress:
 hunter.email_verifier('kevin@instagram.com')
 ```
 
-You can check how many email adresse Hunter has for a given domain:
+You can check how many email addresses Hunter has for a given domain:
 
 ```python
 hunter.email_count('instagram.com')
+```
+
+You can also use a company name if the domain is unknown::
+```python
+hunter.email_count(company='Instagram')
+```
+
+When both domain and company are passed, the domain will be used:
+```python
+hunter.email_count(domain='instagram.com', company='Instagram')
 ```
 
 And you can finally check your account information (PyHunter adds the number of calls still available in the payload):
@@ -80,6 +90,13 @@ And you can finally check your account information (PyHunter adds the number of 
 ```python
 hunter.account_information()
 ```
+
+
+**NOTE:** By default, all of the calls (except `email_verifier()`) return the 'data' element
+of the JSON response. You can get the "raw" response by passing `raw=True` to those calls.
+This gives access to the response headers, e.g. `X-RateLimit-Remaining` returned for the
+`domain_search()` call, and also the complete response body, including `meta`.
+
 
 ### But that's not all folks! As the v2 API added Leads and Leads Lists, these methods are also available on PyHunter
 

--- a/pyhunter/pyhunter.py
+++ b/pyhunter/pyhunter.py
@@ -73,7 +73,7 @@ class PyHunter:
 
         endpoint = self.base_endpoint.format('domain-search')
 
-        return self._query_hunter(endpoint, params)
+        return self._query_hunter(endpoint, params, raw=raw)
 
     def email_finder(self, domain=None, company=None, first_name=None,
                      last_name=None, full_name=None, raw=False):
@@ -124,7 +124,7 @@ class PyHunter:
 
         endpoint = self.base_endpoint.format('email-finder')
 
-        res = self._query_hunter(endpoint, params)
+        res = self._query_hunter(endpoint, params, raw=raw)
         if raw:
             return res
 
@@ -147,7 +147,7 @@ class PyHunter:
 
         endpoint = self.base_endpoint.format('email-verifier')
 
-        return self._query_hunter(endpoint, params)
+        return self._query_hunter(endpoint, params, raw=raw)
 
     def email_count(self, domain=None, company=None, raw=False):
         """

--- a/pyhunter/pyhunter.py
+++ b/pyhunter/pyhunter.py
@@ -10,20 +10,27 @@ class PyHunter:
         self.base_endpoint = 'https://api.hunter.io/v2/{}'
 
     def _query_hunter(self, endpoint, params, request_type='get',
-                      payload=None):
-        if not payload:
-            res = getattr(requests, request_type)(endpoint, params=params)
-        else:
-            res = getattr(requests, request_type)(endpoint, params=params,
-                                                  json=payload)
+                      payload=None, headers=None, raw=False):
+
+        request_kwargs = dict(params=params)
+        if payload:
+            request_kwargs.setdefault(json=payload)
+
+        if headers:
+            request_kwargs.setdefault(headers=headers)
+
+        res = getattr(requests, request_type)(endpoint, **request_kwargs)
         res.raise_for_status()
+
+        if raw:
+            return res
 
         data = res.json()['data']
 
         return data
 
     def domain_search(self, domain=None, company=None, limit=None, offset=None,
-                      emails_type=None):
+                      emails_type=None, raw=False):
         """
         Return all the email addresses found for a given domain.
 
@@ -39,6 +46,8 @@ class PyHunter:
 
         :param emails_type: The type of emails to give back. Can be one of
         'personal' or 'generic'.
+
+        :param raw: Gives back the entire response instead of just the 'data'.
 
         :return: Full payload of the query as a dict, with email addresses
         found.
@@ -124,11 +133,13 @@ class PyHunter:
 
         return email, score
 
-    def email_verifier(self, email):
+    def email_verifier(self, email, raw=False):
         """
         Verify the deliverability of a given email adress.abs
 
         :param email: The email adress to check.
+
+        :param raw: Gives back the entire response instead of just the 'data'.
 
         :return: Full payload of the query as a dict.
         """
@@ -138,23 +149,42 @@ class PyHunter:
 
         return self._query_hunter(endpoint, params)
 
-    def email_count(self, domain):
+    def email_count(self, domain=None, company=None, raw=False):
         """
-        Give back the number of email adresses Hunter has for this domain.
+        Give back the number of email adresses Hunter has for this domain/company.
 
-        :param domain: The domain to check.
+        :param domain: The domain of the company where the person works. Must
+        be defined if company is not. If both 'domain' and 'company' are given,
+        the 'domain' will be used.
+
+        :param company: The name of the company where the person works. Must
+        be defined if domain is not.
+
+        :param raw: Gives back the entire response instead of just the 'data'.
 
         :return: Full payload of the query as a dict.
         """
-        params = {'domain': domain}
+        params = self.base_params
+
+        if not domain and not company:
+            raise MissingCompanyError(
+                'You must supply at least a domain name or a company name'
+            )
+
+        if domain:
+            params['domain'] = domain
+        elif company:
+            params['company'] = company
 
         endpoint = self.base_endpoint.format('email-count')
 
-        return self._query_hunter(endpoint, params)
+        return self._query_hunter(endpoint, params, raw=raw)
 
-    def account_information(self):
+    def account_information(self, raw=False):
         """
         Gives the information about the account associated with the api_key.
+
+        :param raw: Gives back the entire response instead of just the 'data'.
 
         :return: Full payload of the query as a dict.
         """
@@ -162,7 +192,10 @@ class PyHunter:
 
         endpoint = self.base_endpoint.format('account')
 
-        res = self._query_hunter(endpoint, params)
+        res = self._query_hunter(endpoint, params, raw=raw)
+        if raw:
+            return res
+
         res['calls']['left'] = res['calls']['available'] - res['calls']['used']
 
         return res


### PR DESCRIPTION
Hello Quentin!

First let me say, **great library**, thank you for making it available!
I was just about to start implementing a hunter.io API client in Python and I'm glad I found yours! :)

I needed access to the raw response for its headers (like `X-RateLimit-Remaining` returned for `email_verifier()`), and found the `meta` JSON response element to be useful for some requests (e.g. knowing the company name, but not the domain, calling `email_verifier()` with `company=` only returns the domain in the `meta` element).

So here's a summary of the changes done in my small PR:

- Add optional `raw=False` argument to `domain_search()`, `email_count()`, `email_verifier()`, and `account_information()`.
- Add optional `company=None` argument to `email_verifier()` in addition to the existing `domain` argument. As the API docs say, at least one is required, with the domain taking precedence if both are given. Raises `MissingCompanyError` if neither is given, like with `domain_search()`.
- Updated README.md for the changes.

I've tested the changes locally with `raw=True` and `raw=False` to make sure I haven't broken anything. 

Please, let me know what do you think about it. I'd be happy to make other changes if you think they will be needed!