### PR TITLE
catch exception in _query_hunter when there is no data key in the res…

### DIFF
--- a/pyhunter/exceptions.py
+++ b/pyhunter/exceptions.py
@@ -1,6 +1,21 @@
-class MissingCompanyError(Exception):
+
+class PyhunterError(Exception):
+    """
+    Generic exception class for the library
+    """
     pass
 
 
-class MissingNameError(Exception):
+class MissingCompanyError(PyhunterError):
+    pass
+
+
+class MissingNameError(PyhunterError):
+    pass
+
+
+class HunterApiError(PyhunterError):
+    """
+    Represents something went wrong in the call to the Hunter API
+    """
     pass

--- a/pyhunter/pyhunter.py
+++ b/pyhunter/pyhunter.py
@@ -1,6 +1,6 @@
 import requests
 
-from .exceptions import MissingCompanyError, MissingNameError
+from .exceptions import MissingCompanyError, MissingNameError, HunterApiError
 
 
 class PyHunter:
@@ -25,7 +25,10 @@ class PyHunter:
         if raw:
             return res
 
-        data = res.json()['data']
+        try:
+            data = res.json()['data']
+        except KeyError:
+            raise HunterApiError(res.json())
 
         return data
 


### PR DESCRIPTION
…ponse

I encountered a `KeyError` when using the package as the Hunter API had an error on one of my calls. This meant that there was no `data` key in the response from hunter. Since I received a `KeyError` from this I had no way of knowing what caused the issue, my request or a bug at Hunter. To solve this, I have caught the error and raised a `HunterApiError` as well as created a generic error class for the whole library `PyhunterError`.